### PR TITLE
Add link to Home Page on Admin Login screen

### DIFF
--- a/frontend/src/pages/admin/auth/Login.jsx
+++ b/frontend/src/pages/admin/auth/Login.jsx
@@ -107,6 +107,16 @@ const Login = () => {
           </p> */}
         </form>
       </div>
+
+      {/* Added button */}
+      <div className="mt-6 w-full max-w-md text-center">
+        <Link
+          to="/"
+          className="text-sm font-medium text-slate-600 hover:text-slate-800 underline"
+        >
+          ← Back to Home Page
+        </Link>
+      </div>
     </main>
   );
 };


### PR DESCRIPTION
Adds a link below the admin login form to allow users to easily navigate back to the main site

<img width="792" height="776" alt="image" src="https://github.com/user-attachments/assets/d6287495-3ffe-4106-9277-1a54d71309a9" />
