### PR TITLE
Add category dropdown to admin Add/Edit animal and centralize category constants

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -81,7 +81,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1619,7 +1618,6 @@
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1661,7 +1659,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1774,7 +1771,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -1932,8 +1928,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2127,7 +2122,6 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3255,7 +3249,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3338,7 +3331,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3348,7 +3340,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -3675,7 +3666,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
       "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/frontend/src/constants/categories.js
+++ b/frontend/src/constants/categories.js
@@ -1,0 +1,12 @@
+export const CATEGORIES = [
+  { value: "", label: "All Animals", emoji: "🌍" },
+  { value: "Mammal", label: "Mammals", emoji: "🦁" },
+  { value: "Reptile", label: "Reptiles", emoji: "🦎" },
+  { value: "Bird", label: "Birds", emoji: "🦅" },
+  { value: "Amphibian", label: "Amphibians", emoji: "🐸" },
+  { value: "Fish", label: "Fish", emoji: "🐟" },
+  { value: "Insect", label: "Insects", emoji: "🐞" },
+  { value: "Other", label: "Other", emoji: "✨" },
+];
+
+export default CATEGORIES;

--- a/frontend/src/pages/AnimalDetail.jsx
+++ b/frontend/src/pages/AnimalDetail.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useAnimalStore } from "../store/useAnimalStore.js";
+import CATEGORIES from "../constants/categories";
 
 const AnimalDetail = () => {
   const { id } = useParams();
@@ -70,6 +71,9 @@ const AnimalDetail = () => {
 
   const { name, imageUrl, description, title, category } = animal;
 
+  const categoryLabel =
+    CATEGORIES.find((c) => c.value === category)?.label || category || "";
+
   return (
     <section className="relative" aria-label={`${name} details`}>
       <div
@@ -101,7 +105,7 @@ const AnimalDetail = () => {
               </h1>
               {(title || category) && (
                 <p className="mt-1 text-sm text-slate-600">
-                  {(title || category) ?? ""}
+                  {(title || category) ?? categoryLabel}
                 </p>
               )}
               <p className="mt-4 text-slate-700">

--- a/frontend/src/pages/Animals.jsx
+++ b/frontend/src/pages/Animals.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import { useAnimalStore } from "../store/useAnimalStore.js";
 import AnimalCard from "../components/AnimalCard.jsx";
+import CATEGORIES from "../constants/categories";
 
 const Animals = () => {
   const [params, setParams] = useSearchParams();
@@ -20,13 +21,8 @@ const Animals = () => {
     fetchAnimalById,
   } = useAnimalStore();
 
-  // Category options
-  const categories = [
-    { value: "", label: "All Animals", emoji: "🌍" },
-    { value: "mammal", label: "Mammals", emoji: "🦁" },
-    { value: "aquatic", label: "Aquatic", emoji: "🐬" },
-    { value: "bird", label: "Birds", emoji: "🦅" },
-  ];
+  // Category options (centralized)
+  const categories = CATEGORIES;
 
   useEffect(() => {
     fetchAnimals({

--- a/frontend/src/pages/AnimalsCatalogue.jsx
+++ b/frontend/src/pages/AnimalsCatalogue.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import AnimalCard from "../components/AnimalCard";
 import { useAnimalStore } from "../store/useAnimalStore.js";
 import { Link, useNavigate } from "react-router-dom";
+import CATEGORIES from "../constants/categories";
 
 const AnimalsCatalogue = () => {
   const { animals, listLoading, listError, fetchAnimals, fetchAnimalById } =

--- a/frontend/src/pages/admin/animals/AddAnimals.jsx
+++ b/frontend/src/pages/admin/animals/AddAnimals.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAnimalStore } from "../../../store/useAnimalStore";
+import CATEGORIES from "../../../constants/categories";
 import toast from "react-hot-toast";
 
 const AddAnimals = () => {
@@ -144,13 +145,18 @@ const AddAnimals = () => {
               >
                 Category (optional)
               </label>
-              <input
+              <select
                 id="category"
                 value={category}
                 onChange={(e) => setCategory(e.target.value)}
                 className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
-                placeholder="e.g., Mammal"
-              />
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
             </div>
 
             <div className="sm:col-span-2">

--- a/frontend/src/pages/admin/animals/EditAnimals.jsx
+++ b/frontend/src/pages/admin/animals/EditAnimals.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useAnimalStore } from "../../../store/useAnimalStore";
+import CATEGORIES from "../../../constants/categories";
 import toast from "react-hot-toast";
 
 const readFileAsDataURL = (file) =>
@@ -212,13 +213,18 @@ const EditAnimals = () => {
               >
                 Category (optional)
               </label>
-              <input
+              <select
                 id="category"
                 value={category}
                 onChange={(e) => setCategory(e.target.value)}
                 className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
-                placeholder="e.g., Mammal"
-              />
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
             </div>
 
             <div className="sm:col-span-2">


### PR DESCRIPTION
### Description:

**Replaces the free-text category inputs in the admin Add and Edit animal forms with a controlled select dropdown to enforce consistent category values.**
**Introduces a centralized categories constant used across the frontend so labels/values stay consistent (used by admin forms, listing filters, and detail pages).**


**_What I changed_**

**Added:**
 — centralized category list (value, label, emoji)

**Modified:**
— replaced category text input with dropdown
— replaced category text input with dropdown 
 — now usesfor category filter buttons

Why

Prevents inconsistent/typo-prone category values entered manually.
Makes it easy to update category options in one place and reuse them across the UI.
Improves UX by providing explicit, discoverable options in the admin panel.